### PR TITLE
Add method to build the face edge connectivity

### DIFF
--- a/conda_requirements_test.txt
+++ b/conda_requirements_test.txt
@@ -12,6 +12,5 @@
 pytest
 pytest-cov
 progressbar
-pandas
 
 

--- a/conda_requirements_test.txt
+++ b/conda_requirements_test.txt
@@ -12,5 +12,6 @@
 pytest
 pytest-cov
 progressbar
+pandas
 
 

--- a/gridded/pyugrid/ugrid.py
+++ b/gridded/pyugrid/ugrid.py
@@ -844,7 +844,11 @@ class UGrid(object):
         Not implemented yet.
 
         """
-        import pandas as pd
+        try:
+            import pandas
+        except ImportError as err:
+            err.args = ("The pandas package is required to compute the face_edge_connectivity",)
+            raise
 
         faces = self.faces
         edges = self.edges.copy()
@@ -1163,4 +1167,3 @@ class UGrid(object):
             # Add the extra attributes.
             for att_name, att_value in var.attributes.items():
                 setattr(data_var, att_name, att_value)
-

--- a/gridded/pyugrid/ugrid.py
+++ b/gridded/pyugrid/ugrid.py
@@ -874,7 +874,9 @@ class UGrid(object):
             connectivity = df.loc[
                 list(map(tuple, face_edge_2d)), 0
             ].values
-        self.face_edge_connectivity = connectivity.reshape(faces.shape)
+        self.face_edge_connectivity = np.roll(
+            connectivity.reshape(faces.shape), -1, -1
+        )
 
     def build_face_coordinates(self):
         """

--- a/gridded/pyugrid/ugrid.py
+++ b/gridded/pyugrid/ugrid.py
@@ -871,13 +871,9 @@ class UGrid(object):
                 len(face_edge_2d), dtype=face_edge_2d.dtype,
             )
             connectivity.mask = mask
-            connectivity[~mask] = tree.query(
-                face_edge_2d[~mask], eps=1e-5
-            )[1]
+            connectivity[~mask] = tree.query(face_edge_2d[~mask])[1]
         else:
-            connectivity = tree.query(
-                face_edge_2d, eps=1e-5
-            )[1]
+            connectivity = tree.query(face_edge_2d)[1]
         self.face_edge_connectivity = np.roll(
             connectivity.reshape(faces.shape), -1, -1
         )

--- a/gridded/tests/test_ugrid/test_face_edge_connectivity.py
+++ b/gridded/tests/test_ugrid/test_face_edge_connectivity.py
@@ -1,0 +1,35 @@
+"""Test file for building the face_edge_connectivity"""
+import numpy as np
+
+from gridded.pyugrid import ugrid
+
+
+def test_build_face_edge_connectivity():
+    faces = [[0, 1, 2], [1, 2, 3]]
+    edges = [[0, 1], [1, 2], [2, 0], [2, 3], [3, 1]]
+    nodes = [1, 2, 3, 4]
+    grid = ugrid.UGrid(
+        node_lon=nodes, node_lat=nodes, faces=faces, edges=edges
+    )
+
+    ref = [[2, 0, 1], [4, 1, 3]]
+    grid.build_face_edge_connectivity()
+
+    assert grid.face_edge_connectivity.tolist() == ref
+
+
+def test_build_face_edge_connectivity_na():
+    faces = np.ma.array(
+        [[0, 1, 2, 3], [1, 2, 3, -999]],
+        mask=[[False, False, False, False], [False, False, False, True]],
+    )
+    edges = [[0, 1], [1, 2], [2, 3], [3, 0]]
+    nodes = [1, 2, 3, 4]
+    grid = ugrid.UGrid(
+        node_lon=nodes, node_lat=nodes, faces=faces, edges=edges
+    )
+
+    ref = [[3, 0, 1, 2], [-999, 1, 2, -999]]
+    grid.build_face_edge_connectivity()
+
+    assert grid.face_edge_connectivity.filled(-999).tolist() == ref

--- a/gridded/tests/test_ugrid/test_face_edge_connectivity.py
+++ b/gridded/tests/test_ugrid/test_face_edge_connectivity.py
@@ -12,7 +12,7 @@ def test_build_face_edge_connectivity():
         node_lon=nodes, node_lat=nodes, faces=faces, edges=edges
     )
 
-    ref = [[2, 0, 1], [4, 1, 3]]
+    ref = [[0, 1, 2], [1, 3, 4]]
     grid.build_face_edge_connectivity()
 
     assert grid.face_edge_connectivity.tolist() == ref
@@ -29,7 +29,7 @@ def test_build_face_edge_connectivity_na():
         node_lon=nodes, node_lat=nodes, faces=faces, edges=edges
     )
 
-    ref = [[3, 0, 1, 2], [-999, 1, 2, -999]]
+    ref = [[0, 1, 2, 3], [1, 2, -999, -999]]
     grid.build_face_edge_connectivity()
 
     assert grid.face_edge_connectivity.filled(-999).tolist() == ref


### PR DESCRIPTION
as I'll need this for the dual mesh, I thought I start with implementing the face_edge_connectivity. I use the pandas MultiIndex here as it is very efficient (4 seconds for a highres mesh with 1.2 million faces). It add's another dependency, though, but I think pandas is that common nowadays (even within the netCDF-community due to xarray) that this is not a problem. I made pandas an optional dependency (i.e. I only added it to the test requirements file).

What do you think about this approach @ChrisBarker-NOAA and @jay-hennen?