### PR TITLE
Preserve names in grid roundtrip.

### DIFF
--- a/gridded/pyugrid/ugrid.py
+++ b/gridded/pyugrid/ugrid.py
@@ -1154,6 +1154,9 @@ class Mesh(dict):
     REQUIRED = ('cf_role', 'topology_dimension', 'node_coordinates')
     def __init__(self):
         super().__init__()
+        self.update(dict.fromkeys(self.REQUIRED, None))
+        self['name'] = name
+        self['data_model'] = 'NETCDF4'
         self['cf_role'] = 'mesh_topology'
         self['data_model'] = 'NETCDF4'
 
@@ -1191,6 +1194,9 @@ class Mesh(dict):
         return rv
 
 class Dimension(dict):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
     @classmethod
     def from_ncdimension(cls, dimension):
         assert isinstance(dimension, netCDF4.Dimension)
@@ -1200,6 +1206,9 @@ class Dimension(dict):
         return rv
 
 class Variable(dict):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
     @classmethod
     def from_ncvariable(cls, variable):
         assert isinstance(variable, netCDF4.Variable)

--- a/gridded/pyugrid/ugrid.py
+++ b/gridded/pyugrid/ugrid.py
@@ -1173,13 +1173,14 @@ class Mesh(dict):
         # What to do when error condition exists?
         mesh = ncfile.get_variables_by_attributes(cf_role="mesh_topology")[0]
         rv['name'] = mesh.name
-        
+
         # Ensure that the required attributes get copied (or raise an error)
         for k in set(chain(rv.REQUIRED, mesh.ncattrs())):
             rv[k] = getattr(mesh, k)
 
-        rv['dimensions'] = dimensions = {}
-        rv['variables'] = variables = {}
+
+        dimensions = rv['dimensions']
+        variables = rv['variables']
 
         for x in ncfile.dimensions.values():
             dimensions[x.name] = Dimension.from_ncdimension(x)


### PR DESCRIPTION
When a grid is loaded and then saved with gridded, all of the existing names of variables and dimensions get overwritten with generated names.

This PR introduces a strategy to preserve those names by recording them in a dictionary structure. This is still a WIP, but comes from #65 discussion.

Some of the simplified, but incredibly useful ways to use this mapping:
```python
# The mesh_1d object was generated from 1d object http://ugrid-conventions.github.io/ugrid-conventions/#1d-network-topology
# If we want to know what an input name maps to in terms of the spec:
mesh_1d.get_attribute("Mesh1_edge_y")   # Returns 'edge_coordinates'
# If we want to look up what an element of the spec maps to in the input netcdf
mesh_1d['edge_coordinates']  # Returns ['Mesh1_edge_x', 'Mesh1_edge_y']

# If we want to get the values of the edge coordinates of the mesh
mesh_1d.get_values("edge_coordinates", grid_1d)  # Returns grid_1d.edge_coordinates
mesh_1d.get_values("Mesh1_edge_y", grid_1d)  # Returns grid_1d.edge_coordinates[:,1]
```
