### PR TITLE
Fix S_Depth.interpolation_alphas reading level depths from the wrong water column (#106)

### DIFF
--- a/gridded/depth.py
+++ b/gridded/depth.py
@@ -693,8 +693,14 @@ class S_Depth(DepthBase):
         )
 
         # compute the remaining alphas, which should be for points within the depth interval
-        L0 = np.take(transects, indices)
-        L1 = np.take(transects, indices + 1)
+        # transects is (n_points, n_levels): one water column per point, so the bracketing
+        # level depths must be taken from each point's own row. np.take without an axis
+        # would index the flattened array, reading every point's levels out of row 0.
+        # masked or out-of-interval indices were already handled by the boundary conditions
+        # above and are never recomputed below, so fill/clip them to keep the take in bounds.
+        idx = np.clip(np.ma.filled(indices, 0), 0, transects.shape[1] - 2)[:, np.newaxis]
+        L0 = np.take_along_axis(transects, idx, axis=1).squeeze(axis=1)
+        L1 = np.take_along_axis(transects, idx + 1, axis=1).squeeze(axis=1)
         within_layer = np.isnan(alphas)  # remaining alphas would still have nan at this point
         alphas[within_layer] = (depths[within_layer] - L0[within_layer]) / (L1[within_layer] - L0[within_layer])
 

--- a/gridded/tests/test_depth.py
+++ b/gridded/tests/test_depth.py
@@ -386,6 +386,57 @@ class Test_ROMS_Depth:
         assert np.all(idx == expected_idx)
         assert np.all(np.isclose(alphas, expected_alpha))
 
+    def test_interpolation_alphas_multiple_water_columns(self):
+        """
+        Points in DIFFERENT water columns must get their bracketing level depths
+        from their own transect row, not from the first point's water column.
+        interpolation_alphas used np.take without an axis, which indexes the
+        FLATTENED transect array, so every point read its levels out of row 0.
+
+        # query 3 in-bounds points in water columns of 100m / 10m / 40m.
+        # 1st point is 60m deep, between levels 100 and 50: index 0, alpha (60-100)/(50-100) = 0.8
+        # 2nd point is 4m deep, between levels 5 and 2: index 1, alpha (4-5)/(2-5) = 1/3
+        # 3rd point is 10m deep, between levels 20 and 8: index 1, alpha (10-20)/(8-20) = 5/6
+        # 4th point is off grid (fully masked transect), masked index and alpha expected.
+        """
+        nz = 4
+        sd = ROMS_Depth(
+            terms={
+                "s_w": np.linspace(-1, 0, nz),
+                "s_rho": np.linspace(-0.875, -0.125, nz - 1),
+            }
+        )
+        # per-point w-level depths (positive down), one water column per row
+        transects = np.ma.masked_array(
+            data=np.array(
+                [
+                    [100.0, 50.0, 20.0, 0.0],
+                    [10.0, 5.0, 2.0, 0.0],
+                    [40.0, 20.0, 8.0, 0.0],
+                    [50.0, 25.0, 10.0, 0.0],
+                ]
+            ),
+            mask=[[False] * nz, [False] * nz, [False] * nz, [True] * nz],
+        )
+        sd.get_transect = lambda points, time, **kwargs: transects
+
+        points = np.array([[0, 0, 60.0], [1, 1, 4.0], [2, 2, 10.0], [-1, -1, 5.0]])
+        idx, alphas = sd.interpolation_alphas(
+            points,
+            None,
+            [
+                sd.num_levels,
+            ],
+        )
+        expected_idx = np.ma.array(np.array([0, 1, 1, -1000]), mask=[False, False, False, True])
+        expected_alpha = np.ma.array(
+            np.array([0.8, 1.0 / 3.0, 5.0 / 6.0, -1000]), mask=[False, False, False, True]
+        )
+        assert np.all(idx == expected_idx)
+        assert np.all(idx.mask == expected_idx.mask)
+        assert np.all(np.isclose(alphas, expected_alpha, atol=1e-4))
+        assert np.all(alphas.mask == expected_alpha.mask)
+
     def test_interpolation_alphas_surface(self, get_roms_depth):
         sd = get_roms_depth
         points = np.array([[20, 20, -0.1], [20, 20, 0], [20, 20, 0.1]])


### PR DESCRIPTION
# Fix S_Depth.interpolation_alphas reading level depths from the wrong water column

## Summary

`S_Depth.interpolation_alphas` computed the bracketing level depths for each query point with `np.take(transects, indices)` / `np.take(transects, indices + 1)`. `transects` has shape `(n_points, n_levels)` — one water column per point — and `indices` holds per-point level indices, so `np.take` **without an axis** indexed the *flattened* array: every point read its bracketing level depths out of row 0, i.e. the first point's water column. Whenever bathymetry or zeta differ between query points (essentially always in real use), every point after the first gets wrong — often out-of-range — interpolation alphas, silently corrupting 3-D (subsurface) interpolation of ROMS/FVCOM fields through `Variable.at()`.

Fixes #106

## Root cause

`np.take` with no `axis=` argument operates on the flattened array, so per-point level indices `[i0, i1, ...]` were interpreted as flat offsets into row 0 of the `(n_points, n_levels)` transect array instead of per-row lookups `transects[p, i_p]`.

## What the fix changes

In `gridded/depth.py`, the two flattened takes are replaced with a per-row `np.take_along_axis`:

```python
idx = np.clip(np.ma.filled(indices, 0), 0, transects.shape[1] - 2)[:, np.newaxis]
L0 = np.take_along_axis(transects, idx, axis=1).squeeze(axis=1)
L1 = np.take_along_axis(transects, idx + 1, axis=1).squeeze(axis=1)
```

Masked-array behavior is preserved: `MaskedArray.take` filled masked indices with 0; the new code does the same via `np.ma.filled(indices, 0)`, and the per-row fancy indexing keeps the transect mask flowing into `L0`/`L1` (masked points still come back masked). The `np.clip` keeps the lookup in bounds for indices already assigned by the boundary conditions (e.g. above-surface points under the `extrapolate` BC carry `index == surface_index`, for which `index + 1` would be out of bounds in a per-row take; those alphas were set to 0/1 earlier and are never recomputed, so the clipped values are never used).

Why the existing tests didn't catch it: `Test_ROMS_Depth::test_interpolation_alphas` queries every in-bounds point at the same horizontal location (20, 20), so all transect rows are identical and flattened row-0 reads happen to be correct.

## Test evidence

New regression test `Test_ROMS_Depth::test_interpolation_alphas_multiple_water_columns` (no `cell_tree2d` required): a stubbed `ROMS_Depth` with three in-bounds points in *different* water columns (100 m / 10 m / 40 m) plus one horizontally-masked point.

Before the fix (test fails — points 2 and 3 get out-of-range alphas computed from point 1's water column):

```
>       assert np.all(np.isclose(alphas, expected_alpha, atol=1e-4))
E       assert np.False_
E        ...  np.isclose(masked_array(data=[0.8, 1.5333333333333334, 1.3333333333333333, --], ...),
E                        masked_array(data=[0.8, 0.3333333333333333, 0.8333333333333334, --], ...), atol=0.0001)
1 failed in 4.34s
```

After the fix:

```
gridded/tests/test_depth.py::Test_ROMS_Depth::test_interpolation_alphas_multiple_water_columns PASSED
1 passed in 4.41s
```

Full suite (Windows 11, Python 3.14.5, no `cell_tree2d` available — no compiler/wheels on this box):

- base (`origin/main`, bf7bed3): `14 failed, 223 passed, 53 skipped, 1 xfailed`
- this branch: `14 failed, 224 passed, 53 skipped, 1 xfailed`

The 14 failures are identical (diffed) on both: all pre-existing `ImportError: the cell_tree2d package must be installed to use the celltree search`. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
