### PR TITLE
Fix FVCOM_Depth default_names binding siglay_center to siglev_center (#107)

### DIFF
--- a/gridded/depth.py
+++ b/gridded/depth.py
@@ -834,7 +834,7 @@ class FVCOM_Depth(S_Depth):
     _instance_count = 0
     default_names = {
         "siglay": ["siglay"],  # mid layer depth coordinate on nodes
-        "siglay_center": ["siglev_center"],  # mid layer depth coordinate on centers
+        "siglay_center": ["siglay_center"],  # mid layer depth coordinate on centers
         "siglev": ["siglev"],  # layer depth coordinate on nodes
         "siglev_center": ["siglev_center"],  # layer depth coordinate on centers
         "bathymetry": ["h"],  # bathymetry on nodes

--- a/gridded/tests/test_depth.py
+++ b/gridded/tests/test_depth.py
@@ -455,6 +455,14 @@ class Test_FVCOM_Depth:
     def test_construction(self, get_fvcom_depth):
         assert get_fvcom_depth is not None
 
+    def test_default_names_siglay_center(self):
+        # each term should map to the netCDF variable of the same name;
+        # siglay_center pointed at siglev_center (the level-center variable),
+        # so auto-detection silently bound the wrong array to that term
+        assert FVCOM_Depth.default_names["siglay_center"] == ["siglay_center"]
+        # siglev_center keeps its own (correct) mapping
+        assert FVCOM_Depth.default_names["siglev_center"] == ["siglev_center"]
+
     def test_get_transect(self, get_fvcom_depth):
         dp = get_fvcom_depth
         tris = dp.grid.nodes.take(dp.grid.faces, axis=0)


### PR DESCRIPTION
# Fix FVCOM_Depth default_names binding siglay_center to siglev_center

## Summary

`FVCOM_Depth.default_names` mapped the `siglay_center` term to the netCDF variable name `siglev_center` — a lev/lay copy-paste typo. Auto-detection (`search_netcdf_vars`) therefore bound the layer-center sigma term to the *level*-center variable: the wrong array, off by one in the vertical dimension (`n_levels` vs `n_layers`). Any FVCOM file whose layer-center sigma variable is actually named `siglay_center` was never found under that term, and the level-center data was silently substituted.

Fixes #107

## Root cause

One-character typo in the `default_names` dict in `gridded/depth.py`: `"siglay_center": ["siglev_center"]` instead of `["siglay_center"]`.

## What the fix changes

Follows the pattern of the rest of the dict (every term maps to the netCDF variable of the same name — `siglay -> siglay`, `siglev -> siglev`, `siglev_center -> siglev_center`):

```python
"siglay_center": ["siglay_center"],  # mid layer depth coordinate on centers
```

`siglev_center` keeps its own (already correct) mapping.

## Test evidence

New regression test `Test_FVCOM_Depth::test_default_names_siglay_center` asserts `siglay_center` maps to itself and that `siglev_center` retains its own mapping.

Before the fix:

```
E         At index 0 diff: 'siglev_center' != 'siglay_center'
FAILED gridded/tests/test_depth.py::Test_FVCOM_Depth::test_default_names_siglay_center
1 failed in 3.13s
```

After the fix:

```
gridded/tests/test_depth.py::Test_FVCOM_Depth::test_default_names_siglay_center PASSED
1 passed in 4.98s
```

Full suite (Windows 11, Python 3.14.5, no `cell_tree2d` available — no compiler/wheels on this box):

- base (`origin/main`, bf7bed3): `14 failed, 223 passed, 53 skipped, 1 xfailed`
- this branch: `14 failed, 224 passed, 53 skipped, 1 xfailed`

The 14 failures are identical (diffed) on both: all pre-existing `ImportError: the cell_tree2d package must be installed to use the celltree search`. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
