### PR TITLE
Add close()/context-manager support to Dataset

### DIFF
--- a/gridded/gridded.py
+++ b/gridded/gridded.py
@@ -61,6 +61,8 @@ class Dataset:
         If a filename is passed in, the attributes will be pulled from the file, and
         the input ones ignored.
         """
+        self.nc_dataset = None
+
         if ncfile is not None:
             # raise ValueError("don't create from a file")
             warnings.warn(
@@ -136,6 +138,33 @@ class Dataset:
     def __str__(self):
         descp = f"gridded.Dataset with:\ngrid: {type(self.grid)}\nvariables: {list(self.variables.keys())}"
         return descp
+
+    def close(self):
+        """
+        Close the underlying netCDF handle if one is open.
+        """
+        nc_dataset = self.nc_dataset
+        if nc_dataset is None:
+            return
+
+        is_open = getattr(nc_dataset, "isopen", None)
+        if is_open is None or is_open():
+            nc_dataset.close()
+
+        self.nc_dataset = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def _variables_from_netCDF(self, ds):
         """

--- a/gridded/tests/test_dataset.py
+++ b/gridded/tests/test_dataset.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
 
-import os
-
-import netCDF4 as nc
 import pytest
 
 from gridded import Dataset
@@ -91,3 +88,24 @@ def test_save_invalid_format():
 
     with pytest.raises(ValueError):
         ds.save("a_filename.txt", format="text")
+
+
+def test_close_closes_netcdf_handle():
+    gds = Dataset.from_netCDF(sample_sgrid_file)
+    nc_dataset = gds.nc_dataset
+
+    assert nc_dataset.isopen()
+
+    gds.close()
+
+    assert not nc_dataset.isopen()
+    assert gds.nc_dataset is None
+
+
+def test_dataset_context_manager_closes_netcdf_handle():
+    with Dataset.from_netCDF(sample_sgrid_file) as gds:
+        nc_dataset = gds.nc_dataset
+        assert nc_dataset.isopen()
+
+    assert not nc_dataset.isopen()
+    assert gds.nc_dataset is None


### PR DESCRIPTION
This adds deterministic cleanup for Dataset-backed netCDF handles.

- add Dataset.close() and context-manager support for with Dataset.from_netCDF(...)
- make close() idempotent and safe during object cleanup
- add regression tests that assert the handle closes via both close() and context-manager exit

Closes #109.