### PR TITLE
Fix Time data sharing mutations and missing since guard

### DIFF
--- a/gridded/tests/test_time_issue_110.py
+++ b/gridded/tests/test_time_issue_110.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timedelta
+
+import numpy as np
+
+from gridded.time import Time, parse_time_offset
+
+
+def test_new_tz_offset_does_not_mutate_input_array():
+    arr = np.array([datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 6)])
+    original = arr.copy()
+
+    Time(arr, tz_offset=0, new_tz_offset=5)
+
+    assert np.array_equal(arr, original)
+
+
+def test_time_from_time_does_not_share_data():
+    arr = np.array([datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 6)])
+    t1 = Time(arr, tz_offset=0)
+    t2 = Time(t1, tz_offset=0)
+
+    t2.tz_offset = 3
+
+    assert t1.data[0] == datetime(2024, 1, 1, 0)
+
+
+def test_constant_time_returns_isolated_instances():
+    c1 = Time.constant_time()
+    before = c1.data.copy()
+
+    c2 = Time.constant_time()
+    c2.displacement = timedelta(hours=72)
+    c3 = Time.constant_time()
+
+    assert np.array_equal(c1.data, before)
+    assert np.array_equal(c3.data, before)
+
+
+def test_parse_time_offset_without_since(caplog):
+    caplog.clear()
+
+    offset, name = parse_time_offset("days")
+
+    assert offset is None
+    assert name is None
+    assert any("No 'since' in time units string" in rec[2] for rec in caplog.record_tuples)

--- a/gridded/time.py
+++ b/gridded/time.py
@@ -64,7 +64,11 @@ def parse_time_offset(unit_str):
     """
     import dateutil
 
-    t_string = unit_str.split("since")[1]
+    parts = unit_str.split("since", 1)
+    if len(parts) != 2:
+        logging.warning(f"No 'since' in time units string: '{unit_str}'. Setting offset to default")
+        return None, None
+    t_string = parts[1]
     try:
         dt = dateutil.parser.parse(t_string)
     except dateutil.parser.ParserError:
@@ -131,11 +135,11 @@ class Time:
         :type displacement: `datetime.timedelta`
         """
         if isinstance(data, Time):
-            self.data = data.data
+            self.data = data.get_time_array()
         elif data is None:
             self.data = np.array([datetime.now().replace(second=0, microsecond=0)])
         else:
-            self.data = np.asarray(data)
+            self.data = np.array(data, copy=True)
 
         # Quick check to ensure data is 'datetime-like' enough
         try:
@@ -295,7 +299,7 @@ class Time:
         # in the class, and always returns the same one (a singleton)
         if cls._const_time is None:
             cls._const_time = cls(np.array([datetime.now()]))
-        return cls._const_time
+        return cls(cls._const_time)
 
     @property
     def data(self):
@@ -308,7 +312,7 @@ class Time:
         if isinstance(data, self.__class__) or data.__class__ in self.__class__.__mro__:
             data = data.data
         # add check for valid datetime list?
-        self._data = np.asarray(data)
+        self._data = np.array(data, copy=True)
 
     @property
     def info(self):


### PR DESCRIPTION
Fixes #110.\n\nTime now copies incoming arrays (including Time->Time) so tz/origin/displacement shifts stay local to each instance.\nconstant_time() now returns an isolated copy so one caller cannot mutate all constant-time users.\nparse_time_offset() now handles units without "since" by warning and falling back to the default offset path.\n\nAdded regression tests for input-array mutation, Time-from-Time sharing, constant_time isolation, and parse_time_offset("days") fallback behavior.\n\nVerification:\n- python3 -m pytest gridded/tests/test_time_issue_110.py\n- python3 -m pytest gridded/tests/test_time.py -k "new_tz_offset or constant_time or parse_time_offset"\n- python3 -m ruff check gridded/time.py gridded/tests/test_time_issue_110.py