### PR TITLE
Fix DepthBase surface_index and boundary kwargs

### DIFF
--- a/gridded/depth.py
+++ b/gridded/depth.py
@@ -28,7 +28,7 @@ class DepthBase:
         surface_index=-1,
         bottom_index=0,
         default_surface_boundary_condition="extrapolate",
-        default_bottom_boundary_conditon="mask",
+        default_bottom_boundary_condition="mask",
         **kwargs,
     ):
         """
@@ -40,7 +40,10 @@ class DepthBase:
         self._surface_index = surface_index
         self._bottom_index = bottom_index
         self.default_surface_boundary_condition = default_surface_boundary_condition
-        self.default_bottom_boundary_condition = default_bottom_boundary_conditon
+        legacy_bottom_boundary_condition = kwargs.pop("default_bottom_boundary_conditon", None)
+        if legacy_bottom_boundary_condition is not None:
+            default_bottom_boundary_condition = legacy_bottom_boundary_condition
+        self.default_bottom_boundary_condition = default_bottom_boundary_condition
 
     @classmethod
     def _can_create_from_netCDF(
@@ -54,7 +57,7 @@ class DepthBase:
 
     @classmethod
     def from_netCDF(cls, surface_index=-1, **kwargs):
-        return cls(surface_index, **kwargs)
+        return cls(surface_index=surface_index, **kwargs)
 
     @property
     def surface_index(self):

--- a/gridded/tests/test_depth.py
+++ b/gridded/tests/test_depth.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 import gridded
-from gridded.depth import FVCOM_Depth, L_Depth, ROMS_Depth, S_Depth
+from gridded.depth import DepthBase, FVCOM_Depth, L_Depth, ROMS_Depth, S_Depth
 from gridded.grids import Grid_S
 from gridded.tests.utilities import TEST_CDL_FILES, TEST_DATA
 from gridded.time import Time
@@ -41,6 +41,22 @@ def test_from_netCDF():
         #     print("NOT DEPTH:", fn)
         #     continue
         d = S_Depth.from_netCDF(data_file=ds, grid_file=ds)
+
+
+def test_depthbase_from_netcdf_passes_surface_index_keyword():
+    depth = DepthBase.from_netCDF(surface_index=2)
+    assert depth.surface_index == 2
+    assert depth.name is None
+
+
+def test_depthbase_accepts_default_bottom_boundary_condition_spelling():
+    depth = DepthBase(default_bottom_boundary_condition="extrapolate")
+    assert depth.default_bottom_boundary_condition == "extrapolate"
+
+
+def test_depthbase_keeps_legacy_bottom_boundary_condition_spelling():
+    depth = DepthBase(default_bottom_boundary_conditon="extrapolate")
+    assert depth.default_bottom_boundary_condition == "extrapolate"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
DepthBase.from_netCDF(surface_index=...) was passing surface_index positionally into name, so it never reached surface_index. Also, the correctly spelled default_bottom_boundary_condition kwarg was silently ignored because the constructor only used a misspelled parameter name.

This patch passes surface_index as a keyword, accepts the correctly spelled boundary kwarg, and keeps the legacy misspelled kwarg working for compatibility. It also adds regression tests for these constructor paths.

Fixes #108

Verification:
- python3 -m pytest gridded/tests/test_depth.py -k "depthbase"
- python3 -m ruff check gridded/depth.py gridded/tests/test_depth.py --select E9,F821,F822,F823