### PR TITLE
Fix convert_mask_to_numpy_mask returning all-land masks for capitalized flag_meanings or string flag_values

### DIFF
--- a/gridded/tests/test_utilities.py
+++ b/gridded/tests/test_utilities.py
@@ -59,6 +59,48 @@ def test_gen_celltree_mask_from_center_mask():
     testds.close()
 
 
+def test_convert_mask_capitalized_flag_meanings():
+    # CF Conventions 3.5 does not require flag_meanings to be lowercase, so
+    # "Land Water" is valid. The capitalized "Water" used to fail the substring
+    # test and get mapped to land, silently producing an all-land mask (#111).
+    mask_data = np.array([[0, 1], [1, 0]])  # 0 = land, 1 = water
+    expected = np.array([[True, False], [False, True]])
+
+    testds = nc.Dataset("cap", mode="w", diskless=True)
+    testds.createDimension("x", 2)
+    testds.createDimension("y", 2)
+    testds.createVariable("mask", "b", dimensions=("y", "x"))
+    testds["mask"][:] = mask_data
+    testds["mask"].flag_values = [0, 1]
+    testds["mask"].flag_meanings = "Land Water"
+
+    m = utilities.convert_mask_to_numpy_mask(testds["mask"])
+
+    assert np.all(m == expected)
+    testds.close()
+
+
+def test_convert_mask_string_flag_values():
+    # flag_values can arrive as a whitespace string ("0 1"). Its tokens used to
+    # stay strings and never compared equal to the numeric mask data, so the
+    # mask stayed all-land (#111).
+    mask_data = np.array([[0, 1], [1, 0]])  # 0 = land, 1 = water
+    expected = np.array([[True, False], [False, True]])
+
+    testds = nc.Dataset("strfv", mode="w", diskless=True)
+    testds.createDimension("x", 2)
+    testds.createDimension("y", 2)
+    testds.createVariable("mask", "b", dimensions=("y", "x"))
+    testds["mask"][:] = mask_data
+    testds["mask"].flag_values = "0 1"
+    testds["mask"].flag_meanings = "land water"
+
+    m = utilities.convert_mask_to_numpy_mask(testds["mask"])
+
+    assert np.all(m == expected)
+    testds.close()
+
+
 def test_reorganize_spatial_data():
     # 1-dimensional data
     sample_1 = [1, 2, 3]

--- a/gridded/utilities.py
+++ b/gridded/utilities.py
@@ -44,7 +44,19 @@ def convert_mask_to_numpy_mask(mask_var):
             fv = fv.split()
         except AttributeError:
             pass
-        meaning_mask = [False if ("water" in s or "lake" in s) else True for s in fm]
+        else:
+            # flag_values arrived as a string, so its tokens are strings too.
+            # Coerce them to the mask data's dtype so '0' compares equal to a
+            # numeric 0 below; otherwise nothing matches and ret_mask stays
+            # all-land.
+            try:
+                fv = np.asarray(fv, dtype=mask_data.dtype)
+            except (TypeError, ValueError):
+                pass
+        # CF Conventions 3.5 places no case requirement on flag_meanings, so
+        # "Land Water" is valid metadata. Lowercase before the substring test
+        # so capitalized words are recognized as water/lake.
+        meaning_mask = [False if ("water" in s.lower() or "lake" in s.lower()) else True for s in fm]
         tfmap = dict(zip(fv, meaning_mask))
         for k, v in tfmap.items():
             ret_mask[mask_data == k] = v


### PR DESCRIPTION
Some real model files have their whole domain treated as land because convert_mask_to_numpy_mask silently returns an all-land mask for two valid metadata variants (#111). CF Conventions 3.5 doesn't require flag_meanings to be lowercase, so "Land Water" is legal but the capitalized "Water" fails the lowercase substring test and maps to land. Separately, when flag_values arrives as a string like "0 1", the tokens stay strings and never compare equal to the numeric mask data, so nothing gets marked as water.

This lowercases each flag_meanings word before the water/lake check, and coerces string flag_values tokens to the mask variable's dtype so '0' matches a numeric 0. I added two regression tests in test_utilities.py (capitalized flag_meanings and string flag_values); both fail on main and pass with this change, and the existing mask test still passes.
