### PR TITLE
Include the options that change a result in the .at() memo key

### DIFF
--- a/gridded/tests/test_variable.py
+++ b/gridded/tests/test_variable.py
@@ -5,10 +5,15 @@ Variable objects are mostly tested implicitly in other tests,
 but good to have a few explicitly for the Variable object
 """
 
+import datetime
+
 import netCDF4
 import numpy as np
+import pytest
 
 from gridded import Variable, VectorVariable
+from gridded.grids import Grid_S
+from gridded.time import OutOfTimeRangeError, Time
 
 from .utilities import TEST_DATA
 
@@ -156,3 +161,119 @@ def test_VectorVariable_api_at_function_edge_cases():
     assert np.all(r3 == np.ma.MaskedArray([[1, 0], [0, -1]], mask=[[False, False], [True, True]]))
     assert np.all(r1 == r2)
     assert r4.shape == (1, 2)
+
+
+def make_time_series_variable(name="u"):
+    """
+    A Variable on a plain 4x4 grid with three time steps, so that a query
+    outside the time range is out of range rather than constant in time.
+    """
+    node_lat, node_lon = np.mgrid[0:4, 0:4]
+    grid = Grid_S(node_lon=node_lon, node_lat=node_lat)
+    times = np.array([datetime.datetime(2020, 1, 1) + datetime.timedelta(hours=h) for h in range(3)])
+    data = np.stack([np.full((4, 4), float(step)) for step in range(3)])
+    return Variable(name=name, grid=grid, time=Time(data=times), data=data)
+
+
+def test_Variable_at_memo_respects_extrapolate():
+    """
+    A memoized result must not be handed back to a call that asked for
+    different extrapolation behaviour.
+    """
+    var = make_time_series_variable()
+
+    p = [(1.5, 1.5)]
+    t = var.time.max_time + datetime.timedelta(days=1)
+
+    assert var.at(p, t, extrapolate=True) == 2.0
+    with pytest.raises(OutOfTimeRangeError):
+        var.at(p, t, extrapolate=False)
+
+
+def test_Variable_at_memo_respects_unmask():
+    """
+    A memoized filled result must not be handed back to a call that asked for
+    a masked array.
+    """
+    ds = netCDF4.Dataset(sample_sgrid_file)
+    var = Variable.from_netCDF(dataset=ds, varname="u")
+
+    p = [(35.5, 1.5)]  # off the grid, so the result is masked
+    t = var.time.min_time
+
+    filled = var.at(p, t, unmask=True)
+    assert not np.ma.is_masked(filled)
+
+    masked = var.at(p, t, unmask=False)
+    assert np.ma.is_masked(masked)
+
+
+def test_Variable_at_memo_reused_for_identical_calls():
+    """
+    The options taking part in the key must not stop identical calls from
+    being served out of the memo.
+    """
+    ds = netCDF4.Dataset(sample_sgrid_file)
+    var = Variable.from_netCDF(dataset=ds, varname="u")
+
+    p = [(1.5, 35.5)]
+    t = var.time.min_time
+
+    r1 = var.at(p, t)
+    assert len(var._result_memo) == 1
+    r2 = var.at(p, t)
+    assert len(var._result_memo) == 1
+    assert np.all(r1 == r2)
+
+
+def test_Variable_at_memo_respects_boundary_conditions():
+    """
+    The boundary conditions change what ``at`` returns for points outside the
+    depth interval, so they have to take part in the key.
+    """
+    ds = netCDF4.Dataset(sample_sgrid_file)
+    var = Variable.from_netCDF(dataset=ds, varname="u")
+
+    _hash = var._get_hash(np.array([[1.5, 35.5, 0.0]]), var.time.min_time)
+    keys = {
+        var._result_key(_hash, False, False, {}),
+        var._result_key(_hash, False, False, {"surface_boundary_condition": "mask"}),
+        var._result_key(_hash, False, False, {"bottom_boundary_condition": "extrapolate"}),
+    }
+    assert len(keys) == 3
+
+
+def test_VectorVariable_at_memo_respects_extrapolate():
+    """
+    As for Variable: the vector memo must not answer a call that asked for
+    different extrapolation behaviour.
+    """
+    var = VectorVariable(
+        name="vel",
+        variables=[make_time_series_variable("u"), make_time_series_variable("v")],
+    )
+
+    p = [(1.5, 1.5)]
+    t = var.time.max_time + datetime.timedelta(days=1)
+
+    assert np.all(var.at(p, t, extrapolate=True) == 2.0)
+    with pytest.raises(OutOfTimeRangeError):
+        var.at(p, t, extrapolate=False)
+
+
+def test_VectorVariable_at_memo_respects_unmask():
+    """
+    As for Variable: a filled result must not be handed back to a call that
+    asked for a masked array.
+    """
+    ds = netCDF4.Dataset(sample_sgrid_file)
+    var = VectorVariable.from_netCDF(dataset=ds, varnames=["u", "v"])
+
+    p = [(35.5, 1.5)]  # off the grid, so the result is masked
+    t = var.time.min_time
+
+    filled = var.at(p, t, unmask=True)
+    assert not np.ma.is_masked(filled)
+
+    masked = var.at(p, t, unmask=False)
+    assert np.ma.is_masked(masked)

--- a/gridded/variable.py
+++ b/gridded/variable.py
@@ -429,6 +429,22 @@ class Variable:
         """
         return (hashlib.sha1(points.tobytes()).hexdigest(), hashlib.sha1(str(time).encode("utf-8")).hexdigest())
 
+    def _result_key(self, _hash, extrapolate, unmask, kwargs):
+        """
+        Returns the key a result of ``at`` is memoized under.
+
+        ``_hash`` identifies the query points and time only, but the value
+        returned by ``at`` also depends on the options below, so they have to
+        take part in the key.
+        """
+        return (
+            _hash,
+            bool(extrapolate),
+            bool(unmask),
+            kwargs.get("surface_boundary_condition", self.surface_boundary_condition),
+            kwargs.get("bottom_boundary_condition", self.bottom_boundary_condition),
+        )
+
     def _memoize_result(self, points, time, result, D, _copy=False, _hash=None):
         if _copy:
             result = result.copy()
@@ -601,9 +617,10 @@ class Variable:
 
         if _hash is None:
             _hash = self._get_hash(pts, time)
+        _memo_key = self._result_key(_hash, extrapolate, unmask, kwargs)
 
         if _mem:
-            res = self._get_memoed(pts, time, self._result_memo, _hash=_hash)
+            res = self._get_memoed(pts, time, self._result_memo, _hash=_memo_key)
             if res is not None:
                 return res
 
@@ -623,7 +640,7 @@ class Variable:
             value = np.ma.filled(value)
 
         if _mem:
-            self._memoize_result(pts, time, value, self._result_memo, _hash=_hash)
+            self._memoize_result(pts, time, value, self._result_memo, _hash=_memo_key)
         return value
 
     interpolate = at  # common request
@@ -1180,6 +1197,22 @@ class VectorVariable:
         """
         return (hashlib.sha1(points.tobytes()).hexdigest(), hashlib.sha1(str(time).encode("utf-8")).hexdigest())
 
+    def _result_key(self, _hash, extrapolate, unmask, kwargs):
+        """
+        Returns the key a result of ``at`` is memoized under.
+
+        ``_hash`` identifies the query points and time only, but the value
+        returned by ``at`` also depends on the options below, so they have to
+        take part in the key.
+        """
+        return (
+            _hash,
+            bool(extrapolate),
+            bool(unmask),
+            kwargs.get("surface_boundary_condition"),
+            kwargs.get("bottom_boundary_condition"),
+        )
+
     def _memoize_result(self, points, time, result, D, _copy=True, _hash=None):
         if _copy:
             result = result.copy()
@@ -1267,9 +1300,10 @@ class VectorVariable:
         pts = _reorganize_spatial_data(points)
         if _hash is None:
             _hash = self._get_hash(pts, time)
+        _memo_key = self._result_key(_hash, extrapolate, unmask, kwargs)
 
         if _mem:
-            res = self._get_memoed(pts, time, self._result_memo, _hash=_hash)
+            res = self._get_memoed(pts, time, self._result_memo, _hash=_memo_key)
             if res is not None:
                 return res
 
@@ -1290,7 +1324,7 @@ class VectorVariable:
         )
 
         if _mem:
-            self._memoize_result(pts, time, value, self._result_memo, _hash=_hash)
+            self._memoize_result(pts, time, value, self._result_memo, _hash=_memo_key)
 
         return value
 


### PR DESCRIPTION
This PR proposes including the options that change a result — `extrapolate`, `unmask`, and the depth boundary conditions — in the key that `Variable.at()` and `VectorVariable.at()` memoize results under, so a cached value is never handed back to a call that asked for something different. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/453. You can sign in with your GitHub ID to claim ownership of the project.

## What goes wrong

`Variable.at()` and `VectorVariable.at()` store each result in `self._result_memo` under `self._get_hash(pts, time)`, which covers the query points and the time and nothing else. Since `_mem` defaults to `True`, the second of two calls for the same point and time is answered from that memo even when it asked for different behaviour — so what a caller gets back depends on what someone else asked for earlier in the same process.

Two ways that surfaces, both reproduced on `main` at e8978d4:

**`extrapolate` stops being honoured.** A query outside the time range that should raise `OutOfTimeRangeError` quietly returns the extrapolated value instead:

```python
import datetime

import numpy as np

from gridded import Variable
from gridded.grids import Grid_S
from gridded.time import OutOfTimeRangeError, Time

node_lat, node_lon = np.mgrid[0:4, 0:4]
grid = Grid_S(node_lon=node_lon, node_lat=node_lat)
times = np.array([datetime.datetime(2020, 1, 1) + datetime.timedelta(hours=h) for h in range(3)])
data = np.stack([np.full((4, 4), float(step)) for step in range(3)])
var = Variable(name="u", grid=grid, time=Time(data=times), data=data)

p = [(1.5, 1.5)]
t = var.time.max_time + datetime.timedelta(days=1)

print("extrapolate=True  ->", var.at(p, t, extrapolate=True))
try:
    print("extrapolate=False ->", var.at(p, t, extrapolate=False))
except OutOfTimeRangeError:
    print("extrapolate=False -> OutOfTimeRangeError")
```

```
extrapolate=True  -> [[2.0]]
extrapolate=False -> [[2.0]]
```

Drop the first call and `extrapolate=False` raises as documented, so the only thing that changed the answer is the earlier query.

**`unmask` stops being honoured.** A point off the grid comes back as a plain fill value rather than a masked element, so "there is no data here" reads as a real measurement of -999:

```python
var = Variable(name="u", grid=grid, time=Time(data=times), data=data, fill_value=-999.0)

p = [(100.0, 100.0)]  # off the grid
t = var.time.min_time

print("unmask=True  ->", var.at(p, t, unmask=True))
print("unmask=False ->", var.at(p, t, unmask=False))
```

```
unmask=True  -> [[-999.]]
unmask=False -> [[-999.]]
```

## The change

A small `_result_key()` on each class builds the memo key from the existing point/time hash plus `extrapolate`, `unmask`, and the surface/bottom boundary conditions, and `at()` reads and writes `_result_memo` under that instead. What `_get_hash()` returns is untouched, since the grid-level caches key on points and time and are right to.

The boundary conditions arrive in `**kwargs` and are read back with the Variable's own `surface_boundary_condition` / `bottom_boundary_condition` defaults, so a call that does not pass them keys exactly as it did before. There are no signature changes and no new arguments, and results are still memoized: one of the new tests asserts `_result_memo` holds a single entry across two identical calls, so this does not quietly turn the cache off.

With the change, the same two scripts print:

```
extrapolate=True  -> [[2.0]]
extrapolate=False -> OutOfTimeRangeError

unmask=True  -> [[-999.]]
unmask=False -> [[--]]
```

## Verification

Six tests were added to `gridded/tests/test_variable.py` covering both classes: `extrapolate` and `unmask` in the order that trips the defect, the boundary conditions taking part in the key, and the control that identical calls are still served from the memo. Five of the six fail on an unmodified tree and pass with the change; the sixth is the control and passes either way.

`python -m pytest gridded/tests` was run on a clean checkout of `main` and again with this change, in a Python 3.12 environment:

```
before:  242 passed, 53 skipped, 1 xfailed
after:   248 passed, 53 skipped, 1 xfailed
```

Both runs end on the same pair of pre-existing `Test_FVCOM_Depth` setup failures (`ValueError: Time variable 'time' does not match the first dimension of the data variable 'zeta'`), which are untouched by this change. `ruff check gridded` reports the same 121 findings before and after, and none in the two files edited here.

For context rather than as a fix that closes them: #84 describes this memo returning wrong results once the configuration behind them changes, and #30 reports `extrapolate=False` appearing to extrapolate. Neither is closed by this — #84's trigger of setting `surface_index` is no longer reachable since 59189b9 made it read-only, and #30 reports a single call — but both describe the behaviour this key rules out.

## How this was managed

We tracked this work on a live agile board imported from this repository's own issues and pull requests: the story for this fix is at https://eastagiletracker.com/projects/453/stories/401469, on the board at https://eastagiletracker.com/projects/453.

![board](https://raw.githubusercontent.com/eastagiletracker/gridded/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
